### PR TITLE
モデルをS3にデプロイするGitHub Actionsワークフローを追加しました。

### DIFF
--- a/.github/workflows/deploy-model.yml
+++ b/.github/workflows/deploy-model.yml
@@ -1,0 +1,37 @@
+name: Deploy Model to S3
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'artifacts/mushroom.onnx'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github
+        aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
+        
+    - name: Check if model exists
+      run: |
+        if [ ! -f artifacts/mushroom.onnx ]; then
+          echo "Model file not found, skipping upload"
+          exit 0
+        fi
+        
+    - name: Upload to S3 with overwrite
+      run: |
+        aws s3 cp artifacts/mushroom.onnx s3://${{ vars.S3_BUCKET }}/models/mushroom.onnx --metadata "uploaded=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "Model uploaded to S3 successfully at $(date)"


### PR DESCRIPTION
  ## Summary

  developブランチへのマージ時に `artifacts/mushroom.onnx` モデルファイルを自動でS3にアップロードするGitHub Actionsワークフローを追加。

  - トリガー: developブランチへのpush + `artifacts/mushroom.onnx`の変更検知
  - 認証: IAM `github` ロールを使用したOIDC認証
  - アップロード先: `s3://{S3_BUCKET}/models/mushroom.onnx`
  - ファイル存在チェック + 上書きアップロード対応

  ## 必要な設定

  Repository Variables:
  - `AWS_ACCOUNT_ID`: AWSアカウントID
  - `S3_BUCKET`: アップロード先S3バケット名
  - `AWS_REGION`: AWSリージョン (デフォルト: us-west-2)

  ## Test plan

  - [x] Variables設定後、テスト用ONNXファイルでワークフロー実行確認
  - [ ] S3への正常アップロード確認
  - [ ] ファイル非存在時のスキップ動作確認