### PR TITLE
AWS認証をOIDCからアクセスキー方式に変更

### DIFF
--- a/.github/workflows/deploy-model.yml
+++ b/.github/workflows/deploy-model.yml
@@ -11,7 +11,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     
     steps:
@@ -21,7 +20,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
         
     - name: Check if model exists


### PR DESCRIPTION
## Summary
- GitHub ActionsのAWS認証方式をOIDC role assumptionからアクセスキー方式に変更
- OIDC providerが設定されていないことによるエラーを修正
- 必要な権限設定を簡素化

## Test plan
- [ ] AWS_ACCESS_KEY_IDとAWS_SECRET_ACCESS_KEYシークレットの設定
- [ ] AWS_REGIONとS3_BUCKETリポジトリ変数の設定  
- [ ] ワークフローの実行確認

🤖 Generated with [Claude Code](https://claude.ai/code)